### PR TITLE
Update to support new versions of moment.js

### DIFF
--- a/tzdetect.js
+++ b/tzdetect.js
@@ -5,13 +5,13 @@
 //   tzdetect.names : an array of all available timezone id
 //   tzdetect.matches() : returns an array of all timezones matching the user's one
 var tzdetect = {
-	names:[],
+	names: moment.tz.names(),
 	matches: function(){
 		var results = [], now = Date.now(), makekey = function(id){
 			return [0, 4, 8, -5*12, 4-5*12, 8-5*12, 4-2*12, 8-2*12].map(function(months){
 				var m = moment(now + months*30*24*60*60*1000);
 				if (id) m.tz(id);
-				return m.format("DDHH")
+				return m.format("DDHH");
 			}).join(' ');
 		}, lockey = makekey();
 		tzdetect.names.forEach(function(id){
@@ -20,8 +20,3 @@ var tzdetect = {
 		return results;
 	}
 };
-tzdetect.originalTzAdd = moment.tz.add;
-moment.tz.add = function(data){
-	if (data.zones) tzdetect.names = tzdetect.names.concat(Object.keys(data.zones));
-	tzdetect.originalTzAdd.call(moment.tz, data);
-}


### PR DESCRIPTION
This is a proposed update for moment.js 2.7.0 + moment-timezone 0.1.0. Lines 24 to 28 were trying to preprocess the Olson IDs before they were added to the dataset in moment-timezone by using the "moment.tz.add" function. However, the new version of moment-timezone seems to have a get function that returns a sorted list of all available Olson IDs. I simply assigned the "names" array using this new function.
