### PR TITLE
Matching time format now includes minutes

### DIFF
--- a/tzdetect.js
+++ b/tzdetect.js
@@ -3,17 +3,18 @@
 // It must be included between the moment-timezone.js script and the moment-timezone-data.js one.
 // Usage :
 //   tzdetect.names : an array of all available timezone id
-//   tzdetect.matches() : returns an array of all timezones matching the user's one
+//   tzdetect.matches(base) : returns an array of all timezones matching the user's one, or supplied base timezone
 var tzdetect = {
 	names: moment.tz.names(),
-	matches: function(){
+	matches: function(base){
 		var results = [], now = Date.now(), makekey = function(id){
 			return [0, 4, 8, -5*12, 4-5*12, 8-5*12, 4-2*12, 8-2*12].map(function(months){
 				var m = moment(now + months*30*24*60*60*1000);
 				if (id) m.tz(id);
-				return m.format("DDHH");
+				// Compare using day of month, hour and minute (some timezones differ by 30 minutes)
+				return m.format("DDHHmm");
 			}).join(' ');
-		}, lockey = makekey();
+		}, lockey = makekey(base);
 		tzdetect.names.forEach(function(id){
 			if (makekey(id)===lockey) results.push(id);
 		});


### PR DESCRIPTION
Changed matching time format to include minutes so that timezones which differ by less than 60 minutes are not incorrectly returned.
Also, match() takes an optional base timezone - so all timezones matching either the user's current timezone. or supplied base timezone are returned.
